### PR TITLE
corregido fallo de dependencias en el pom.xml del ejb y modificadas l…

### DIFF
--- a/Dokulearning/Dokulearning-ear/pom.xml
+++ b/Dokulearning/Dokulearning-ear/pom.xml
@@ -4,7 +4,7 @@
   <parent>
         <artifactId>Dokulearning</artifactId>
         <groupId>es.uc3m.tiw</groupId>
-        <version>1.0</version>
+        <version>3.0</version>
         <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/Dokulearning/Dokulearning-ejb/pom.xml
+++ b/Dokulearning/Dokulearning-ejb/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>Dokulearning</artifactId>
         <groupId>es.uc3m.tiw</groupId>
-        <version>1.0</version>
+        <version>3.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -25,6 +25,12 @@
             <artifactId>javaee-api</artifactId>
            
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+        	<groupId>es.uc3m.tiw.model</groupId>
+        	<artifactId>Dokulearning-model</artifactId>
+        	<version>${project.parent.version}</version>
+        	<scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/Dokulearning/Dokulearning-model/pom.xml
+++ b/Dokulearning/Dokulearning-model/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>es.uc3m.tiw</groupId>
     <artifactId>Dokulearning</artifactId>
-    <version>1.0</version>
+    <version>3.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <groupId>es.uc3m.tiw.model</groupId>

--- a/Dokulearning/Dokulearning-util/pom.xml
+++ b/Dokulearning/Dokulearning-util/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>es.uc3m.tiw</groupId>
     <artifactId>Dokulearning</artifactId>
-    <version>1.0</version>
+    <version>3.0</version>
   </parent>
   <groupId>es.uc3m.tiw.util</groupId>
   <artifactId>Dokulearning-util</artifactId>

--- a/Dokulearning/Dokulearning-web/pom.xml
+++ b/Dokulearning/Dokulearning-web/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>Dokulearning</artifactId>
         <groupId>es.uc3m.tiw</groupId>
-        <version>1.0</version>
+        <version>3.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/Dokulearning/pom.xml
+++ b/Dokulearning/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>es.uc3m.tiw</groupId>
 	<artifactId>Dokulearning</artifactId>
-	<version>1.0</version>
+	<version>3.0</version>
 	<packaging>pom</packaging>
 	<name>TIW-Archetype</name>
 	<description>Archetype for rapid development. This archetype build a parent project with submodules like EAR, EJB, WAR, Util and Persistence model.


### PR DESCRIPTION
## Fallo corregido de dependencias

Arreglado en el _pom.xml_ del proyecto _ejb_. Faltaba una dependencia al proyecto model, por lo que hacia imposible generar el _EAR_ correspondiente y por tanto desplegar.

Se ha modificado la version tambien en todos los _pom.xml_ para adaptarla a la ultima entrega 
